### PR TITLE
Indentation error fix in sam.yaml at Events

### DIFF
--- a/src/sam.yaml
+++ b/src/sam.yaml
@@ -63,7 +63,7 @@ Resources:
           CURRENT_MONTH: !Ref CurrentMonth
           INC_SUPPORT: 'false'
           INC_TAX: 'true'
-     Events:
+      Events:
         MonthlyEvent:
           Properties:
             Schedule: !Sub cron(0 1 ${DayOfMonth} * ? *)


### PR DESCRIPTION
This change will fix the following error in the AWS::Serverless::Function lambda function after running
sh deploy.sh

*Issue:*

while parsing a block mapping
  in "<unicode string>", line 43, column 5:
        Type: 'AWS::Serverless::Function'
        ^ (line: 43)
expected <block end>, but found '<block mapping start>'
  in "<unicode string>", line 66, column 6:
         Events:
         ^ (line: 66)

*Description of changes:*

Adding a space fixes the indentation error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
